### PR TITLE
Added django.conf.settings

### DIFF
--- a/django/conf/__init__.pyi
+++ b/django/conf/__init__.pyi
@@ -1,0 +1,4 @@
+from typing import Any
+
+
+settings = ...  # type: Any


### PR DESCRIPTION
Fixes the error "error: Module 'django.conf' has no attribute 'settings'"