### PR TITLE
Update install command to the latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ polls/views.py:41: error: Return type of "get_template_names" incompatible with 
 ## Installation and usage
 
 You'll need to install mypy (other PEP-484 checkers might work, but I haven't tested them).
-`pip install mypy-lang` should do the trick. There are no other requirements.
+`pip install mypy` should do the trick. There are no other requirements.
 
 This is not a python package (no actual executable code), so this is not installed with `pip` or
 available in [PyPI](https://pypi.python.org/pypi). You can just `git clone` the latest version from


### PR DESCRIPTION
mypy-lang has moved to mypy now, so in order to install the latest mypy `pip install mypy is needed, not mypy-lang.

More details here:
- https://github.com/python/mypy/commit/339ba96d1c36894577db072a0f90656fea83a05a#diff-04c6e90faac2675aa89e2176d2eec7d8